### PR TITLE
Fixed linker errors when included in multiple .cpp files

### DIFF
--- a/src/AsyncHTTPRequest_Debug_Generic.h
+++ b/src/AsyncHTTPRequest_Debug_Generic.h
@@ -24,8 +24,7 @@
   1.0.0    K Hoang     14/09/2020 Initial coding to add support to STM32 using built-in Ethernet (Nucleo-144, DISCOVERY, etc).
  *****************************************************************************************************************************/
  
-#ifndef AsyncHTTPRequest_Debug_STM32_H
-#define AsyncHTTPRequest_Debug_STM32_H
+#pragma once
 
 #ifdef ASYNC_HTTP_DEBUG_PORT
   #define A_DBG_PORT      ASYNC_HTTP_DEBUG_PORT
@@ -67,5 +66,3 @@
 #define AHTTP_LOGDEBUG1(x,y)      if(_ASYNC_HTTP_LOGLEVEL_>3) { A_DBG_PORT.print("[AHTTP] "); A_DBG_PORT.print(x); A_DBG_PORT.print(" "); A_DBG_PORT.println(y); }
 #define AHTTP_LOGDEBUG2(x,y,z)    if(_ASYNC_HTTP_LOGLEVEL_>3) { A_DBG_PORT.print("[AHTTP] "); A_DBG_PORT.print(x); A_DBG_PORT.print(" "); A_DBG_PORT.print(y); A_DBG_PORT.print(" "); A_DBG_PORT.println(z); }
 #define AHTTP_LOGDEBUG3(x,y,z,w)  if(_ASYNC_HTTP_LOGLEVEL_>3) { A_DBG_PORT.print("[AHTTP] "); A_DBG_PORT.print(x); A_DBG_PORT.print(" "); A_DBG_PORT.print(y); A_DBG_PORT.print(" "); A_DBG_PORT.print(z); A_DBG_PORT.print(" "); A_DBG_PORT.println(w); }
-
-#endif    // AsyncHTTPRequest_Debug_STM32_H

--- a/src/AsyncHTTPRequest_Generic.h
+++ b/src/AsyncHTTPRequest_Generic.h
@@ -24,8 +24,7 @@
   1.0.0    K Hoang     14/09/2020 Initial coding to add support to STM32 using built-in Ethernet (Nucleo-144, DISCOVERY, etc).
  *****************************************************************************************************************************/
  
-#ifndef AsyncHTTPRequest_Generic_h
-#define AsyncHTTPRequest_Generic_h
+#pragma once
 
 #define AsyncHTTPRequest_Generic_version   "1.0.0"
 
@@ -263,7 +262,3 @@ class AsyncHTTPRequest
     void        _onPoll(AsyncClient*);
     bool        _collectHeaders();
 };
-
-#include "AsyncHTTPRequest_Impl_Generic.h"
-
-#endif    // AsyncHTTPRequest_Generic_h

--- a/src/AsyncHTTPRequest_Impl_Generic.cpp
+++ b/src/AsyncHTTPRequest_Impl_Generic.cpp
@@ -23,12 +23,8 @@
   ------- -----------  ---------- -----------
   1.0.0    K Hoang     14/09/2020 Initial coding to add support to STM32 using built-in Ethernet (Nucleo-144, DISCOVERY, etc).
  *****************************************************************************************************************************/
- 
-#pragma once
 
-#ifndef AsyncHTTPRequest_Impl_Generic_h
-#define AsyncHTTPRequest_Impl_Generic_h
-
+#include "AsyncHTTPRequest_Generic.h"
 
 //**************************************************************************************************************
 AsyncHTTPRequest::AsyncHTTPRequest(): _readyState(readyStateUnsent), _HTTPcode(0), _chunked(false), _debug(DEBUG_IOTA_HTTP_SET)
@@ -1187,5 +1183,3 @@ char* AsyncHTTPRequest::_charstar(const __FlashStringHelper * str)
 }
 
 #endif
-
-#endif    // AsyncHTTPRequest_Impl_Generic_h

--- a/src/utility/xbuf.h
+++ b/src/utility/xbuf.h
@@ -148,6 +148,4 @@ class xbuf: public Print
 
 };
 
-#include "utility/xbuf_Impl.h"
-
 #endif    // xbuf_h

--- a/src/utility/xbuf_Impl.cpp
+++ b/src/utility/xbuf_Impl.cpp
@@ -27,7 +27,7 @@
 #ifndef xbuf_Impl_h
 #define xbuf_Impl_h
 
-//#include "utility/xbuf.h"
+#include "utility/xbuf.h"
 
 xbuf::xbuf(const uint16_t segSize) : _head(nullptr), _tail(nullptr), _used(0), _free(0), _offset(0) 
 {


### PR DESCRIPTION
Hi,

I was using your library in my project, and when I started including your .h files in multiple .cpp files (compile units), the linker started complaining, as all your symbols where exported from multiple .o files.

I moved your implementations into .cpp files, which allows for linkage instead of inlining, which should not affect performance much.