### PR TITLE
Fix issue where stm32 librarys are made dependency #14

### DIFF
--- a/library.json
+++ b/library.json
@@ -34,7 +34,7 @@
       "owner": "me-no-dev",
       "name": "ESPAsyncTCP",
       "version": ">=1.2.2",
-      "platforms": "espressif8266"
+      "platforms": ["espressif8266"]
     },
     {
       "owner": "khoih.prog",
@@ -46,13 +46,13 @@
       "owner": "stm32duino",
       "name": "STM32duino LwIP",
       "version": ">=2.1.2",
-      "platforms": "ststm32"
+      "platforms": ["ststm32"]
     },
     {
       "owner": "stm32duino",
       "name": "STM32Ethernet",
       "version": ">=1.2.0",
-      "platforms": "ststm32"
+      "platforms": ["ststm32"]
     },
     {
       "owner": "lorol",


### PR DESCRIPTION
- Put the platforms in [] under dependencies

"Platforms" has to be an array or CSV string.

https://github.com/platformio/platformio-core/blob/55408f6ccb9c90a7e0abaea548b688bd780639dc/platformio/builder/tools/piolib.py#L811