### PR TITLE
Remove unavailable items from `depends` field of library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,5 +8,5 @@ paragraph=This AsyncHTTPRequest_Generic Library, supporting GET, POST, PUT, PATC
 category=Communication,AsyncTCP,AsyncHTTP
 url=https://github.com/khoih-prog/AsyncHTTPRequest_Generic
 architectures=*
-depends=AsyncTCP, ESPAsyncTCP, ESPAsync_WiFiManager, STM32duino LwIP, STM32duino STM32Ethernet, WebServer_WT32_ETH01
+depends=ESPAsync_WiFiManager, STM32duino LwIP, STM32duino STM32Ethernet, WebServer_WT32_ETH01
 includes=AsyncHTTPRequest_Generic.h,AsyncHTTPRequest_Generic.hpp


### PR DESCRIPTION
The `depends` field of [the library.properties metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format) specifies the dependencies that should be installed along with
the library by the [Arduino Library Manager](https://docs.arduino.cc/software/ide-v1/tutorials/installing-libraries#using-the-library-manager).

This field must contain only the names of libraries that are available for installation via Library Manager.

The presence of any items which are not in Library Manager causes installation of the library to fail:

- [Arduino IDE 1.x](https://github.com/arduino/Arduino): "`no protocol:`" error
- [Arduino IDE 2.x](https://github.com/arduino/arduino-ide): fails silently ([`arduino/arduino-ide#621`](https://github.com/arduino/arduino-ide/issues/621))
- [Arduino CLI](https://arduino.github.io/arduino-cli/latest/): "`No valid dependencies solution found`" error

Originally reported at https://forum.arduino.cc/t/arduino-sdk-error-trying-to-download-library/967231

### Related

- https://github.com/me-no-dev/AsyncTCP/issues/147
- https://github.com/me-no-dev/ESPAsyncTCP/issues/139
- https://github.com/me-no-dev/ESPAsyncTCP/issues/158
- https://github.com/me-no-dev/ESPAsyncTCP/issues/168