### PR TITLE
Fix "blank new line in chunk" bug

### DIFF
--- a/src/AsyncHTTPRequest_Impl_Generic.h
+++ b/src/AsyncHTTPRequest_Impl_Generic.h
@@ -1448,7 +1448,7 @@ void  AsyncHTTPRequest::_processChunks()
     size_t chunkLength = strtol(chunkHeader.c_str(), nullptr, 16);
     _contentLength += chunkLength;
 
-    if (chunkLength == 0)
+    if (chunkHeader == "0\r\n")
     {
       char* connectionHdr = respHeaderValue("connection");
 


### PR DESCRIPTION
If a chunk contains an empty line ("\r\n") chunkLength will be 0 and _setReadyState(readyStateDone) will be called, resulting in truncated payloads. We actually need to wait for "0\r\n" to set state as done.